### PR TITLE
fix bugs in the get_low_dim_data function

### DIFF
--- a/rlbench/backend/observation.py
+++ b/rlbench/backend/observation.py
@@ -45,11 +45,11 @@ class Observation(object):
 
         :return: 1D array of observations.
         """
-        low_dim_data = [] if self.gripper_open is None else [self.gripper_open]
+        low_dim_data = [] if self.gripper_open is None else [[self.gripper_open]]
         for data in [self.joint_velocities, self.joint_positions,
                      self.joint_forces,
                      self.gripper_pose, self.gripper_joint_positions,
                      self.gripper_touch_forces, self.task_low_dim_state]:
             if data is not None:
-                low_dim_data.extend(data)
+                low_dim_data.append(data)
         return np.concatenate(low_dim_data)


### PR DESCRIPTION
Found a bug in the function `def get_low_dim_data(self) -> np.ndarray` from the `rlbench/backend/observation.py` file. The `np.concatenate` cannot handle a single flatten list or mixed with `float` type data like `self.gripper_open`. Otherwise, it will have error like: `ValueError: zero-dimensional arrays cannot be concatenated`