### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 Pillow
 pyquaternion
 html-testRunner
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 # Version meaning (X.Y.Z)
 # X: Major version (e.g. vastly different scene, platform, etc)


### PR DESCRIPTION
This PR replaces `distutils` with `setuptools`, primarily since `setuptools` has some nice features which are missing in `distutils`; for example, one can set up the package in `develop` mode, which speeds up development/debugging. `setuptools` is additionally the recommended tool for package setup [1].

[1] https://packaging.python.org/guides/tool-recommendations/