### PR TITLE
fix some possible typos in helper script

### DIFF
--- a/tools/dataset_generator.py
+++ b/tools/dataset_generator.py
@@ -163,7 +163,7 @@ def save_demo(demo, example_path):
 
     # Save the low-dimension data
     with open(os.path.join(example_path, LOW_DIM_PICKLE), 'wb') as f:
-        pickle.dump(demo, f)
+        pickle.dump([obs.get_low_dim_data() for obs in demo], f)
 
 
 def run(i, lock, task_index, variation_count, results, file_lock, tasks):
@@ -243,7 +243,7 @@ def run(i, lock, task_index, variation_count, results, file_lock, tasks):
 
         task_env = rlbench_env.get_task(t)
         task_env.set_variation(my_variation_count)
-        obs, descriptions = task_env.reset()
+        descriptions, _ = task_env.reset()
 
         variation_path = os.path.join(
             FLAGS.save_path, task_env.get_name(),

--- a/tools/dataset_generator.py
+++ b/tools/dataset_generator.py
@@ -163,7 +163,7 @@ def save_demo(demo, example_path):
 
     # Save the low-dimension data
     with open(os.path.join(example_path, LOW_DIM_PICKLE), 'wb') as f:
-        pickle.dump([obs.get_low_dim_data() for obs in demo], f)
+        pickle.dump(demo, f)
 
 
 def run(i, lock, task_index, variation_count, results, file_lock, tasks):


### PR DESCRIPTION
This issue is related to #182 . It also fixes a similar problem when pickling the low-dimensional data (it was pickling the whole demo instead)