### PR TITLE
Store the variation index in the misc of demos

### DIFF
--- a/rlbench/backend/scene.py
+++ b/rlbench/backend/scene.py
@@ -539,4 +539,5 @@ class Scene(object):
         misc.update(_get_cam_data(self._cam_overhead, 'overhead_camera'))
         misc.update(_get_cam_data(self._cam_front, 'front_camera'))
         misc.update(_get_cam_data(self._cam_wrist, 'wrist_camera'))
+        misc.update({"variation_index": self._variation_index})
         return misc

--- a/rlbench/task_environment.py
+++ b/rlbench/task_environment.py
@@ -163,4 +163,6 @@ class TaskEnvironment(object):
 
     def reset_to_demo(self, demo: Demo) -> (List[str], Observation):
         demo.restore_state()
+        variation_index = demo._observations[0].misc["variation_index"]
+        self.set_variation(variation_index)
         return self.reset()


### PR DESCRIPTION
store the variation index in the misc of demos and fix the `reset_to_demo` function by supporting restoring back to the stored variance index.