### PR TITLE
Fix missing joint_position_action and add gripper action

### DIFF
--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -263,3 +263,29 @@ class TestEnvironment(unittest.TestCase):
                     robot_setup=robot_config)
                 self.env.launch()
                 self.env.shutdown()
+
+    def test_executed_jp_action(self):
+        for task_cls in [ReachTarget, TakeLidOffSaucepan]:
+            task = self.get_task(
+                task_cls, JointPosition(True))
+            demos = task.get_demos(5, live_demos=True)
+            # Check if executed joint position action is stored
+            for demo in demos:
+                jp_action = []
+                self.assertTrue("joint_position_action" not in demo[0].misc)
+                for t, obs in enumerate(demo):
+                    if t == 0:
+                        # First timestep should not have an action
+                        self.assertTrue('joint_position_action' not in obs.misc)
+                    else:
+                        self.assertTrue("joint_position_action" in obs.misc)
+                        jp_action.append(obs.misc["joint_position_action"])
+
+                task.reset_to_demo(demo)
+                for t, action in enumerate(jp_action):
+                    # action = np.append(action, 1)
+                    obs, reward, term = task.step(action)
+                    if term:
+                        break
+                self.assertEqual(reward, 1.0)
+                    


### PR DESCRIPTION
- Fix #209, where some timesteps have missing actions.
- Rename obs.misc["executed_demo_joint_position_action"] to obs.misc["joint_position_action"]
- Add test for replaying joint position action.

TODO:
- [ ] Change pyrep commit hash in setup.py once https://github.com/stepjam/PyRep/pull/371 is merged.