### PR TITLE
Hotfix -- Change default max acceleration for dataset generator

### DIFF
--- a/rlbench/dataset_generator.py
+++ b/rlbench/dataset_generator.py
@@ -290,7 +290,7 @@ def parse_args():
     parser.add_argument('--episodes_per_task', type=int, default=10, help='The number of episodes to collect per task.')
     parser.add_argument('--variations', type=int, default=-1, help='Number of variations to collect per task. -1 for all.')
     parser.add_argument('--arm_max_velocity', type=float, default=1.0, help='Max arm velocity used for motion planning.')
-    parser.add_argument('--arm_max_acceleration', type=float, default=1.0, help='Max arm acceleration used for motion planning.')
+    parser.add_argument('--arm_max_acceleration', type=float, default=4.0, help='Max arm acceleration used for motion planning.')
     return parser.parse_args()
 
 


### PR DESCRIPTION
Value was set to 1.0, but it should be 4.0.