### PR TITLE
Fix ValueError in imitation learning example for ragged arrays

### DIFF
--- a/examples/imitation_learning.py
+++ b/examples/imitation_learning.py
@@ -36,7 +36,7 @@ task = env.get_task(ReachTarget)
 il = ImitationLearning()
 
 demos = task.get_demos(2, live_demos=live_demos)  # -> List[List[Observation]]
-demos = np.array(demos).flatten()
+demos = np.array(demos, dtype=object).flatten()
 
 # An example of using the demos to 'train' using behaviour cloning loss.
 for i in range(100):


### PR DESCRIPTION
In numpy 1.19, Creating ragged arrays via `np.array([<ragged_nested_sequence>])` with no dtype keyword will raise `ValueError`, so I added `dtype=object` to fix that.